### PR TITLE
Don't let uploaded images in the richtext area overflow the widget

### DIFF
--- a/source/app.css
+++ b/source/app.css
@@ -94,3 +94,7 @@ cloudflare-app[app="self-summary"] summary-profile-picture {
     display: block;
   }
 }
+
+cloudflare-app[app="self-summary"] img {
+  max-width: 100%;
+}


### PR DESCRIPTION
When you upload an image in the richtext area which is too wide right now it overflows the container, this should fix that.